### PR TITLE
Fixed linter warning about cast lossless

### DIFF
--- a/analyze/analyze.rs
+++ b/analyze/analyze.rs
@@ -52,6 +52,7 @@ impl fmt::Display for Table {
         let last = self.header.len() - 1;
 
         for (i, h) in self.header.iter().map(|h| &h.1).enumerate() {
+
             if i == 0 {
                 write!(f, " ")?;
             } else {
@@ -139,7 +140,7 @@ impl traits::Emit for Top {
                 item.size()
             };
 
-            let size_percent = (size as f64) / (items.size() as f64) * 100.0;
+            let size_percent = (f64::from(size)) / (f64::from(items.size())) * 100.0;
             table.add_row(vec![
                 size.to_string(),
                 format!("{:.2}%", size_percent),
@@ -234,7 +235,7 @@ impl traits::Emit for DominatorTree {
                 let item = &items[id];
 
                 let size = items.retained_size(id);
-                let size_percent = (size as f64) / (items.size() as f64) * 100.0;
+                let size_percent = (f64::from(size)) / (f64::from(items.size())) * 100.0;
 
                 let mut label = String::with_capacity(depth * 4 + item.name().len() + "⤷ ".len());
                 for _ in 2..depth {
@@ -342,7 +343,7 @@ impl traits::Emit for Paths {
                     "".to_string()
                 },
                 if depth == 0 {
-                    let size_percent = (item.size() as f64) / (items.size() as f64) * 100.0;
+                    let size_percent = (f64::from(item.size())) / (f64::from(items.size())) * 100.0;
                     format!("{:.2}%", size_percent)
                 } else {
                     "".to_string()

--- a/ir/ir.rs
+++ b/ir/ir.rs
@@ -79,7 +79,7 @@ impl ItemsBuilder {
 
     /// Add a range of static data and the `Id` that defines it.
     pub fn link_data(&mut self, offset: i64, len: usize, id: Id) {
-        if offset >= 0 && offset <= u32::MAX as i64 && offset as usize + len < u32::MAX as usize {
+        if offset >= 0 && offset <= i64::from(u32::MAX) && offset as usize + len < u32::MAX as usize {
             self.data.insert(offset as u32, (id, len as u32));
         }
     }

--- a/parser/wasm.rs
+++ b/parser/wasm.rs
@@ -679,7 +679,7 @@ impl<'a> Parse<'a> for elements::DataSection {
             let ty = None;
             let offset_code = d.offset().code();
             let offset = offset_code.get(0).and_then(|op| match *op {
-                I32Const(o) => Some(o as i64),
+                I32Const(o) => Some(i64::from(o)),
                 I64Const(o) => Some(o),
                 _ => None,
             });


### PR DESCRIPTION
Fixed [warning](https://rust-lang-nursery.github.io/rust-clippy/master/index.html#cast_lossless) about cast lossles from [clippy linter](https://github.com/rust-lang-nursery/rust-clippy).

